### PR TITLE
Visualize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ buck-out/
 \.buckd/
 android/app/libs
 *.keystore
+
+auth0-credentials.js

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -126,6 +126,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-svg')
     compile project(':react-native-lock')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"

--- a/android/app/src/main/java/com/hoopdreams/MainApplication.java
+++ b/android/app/src/main/java/com/hoopdreams/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.util.Log;
 
 import com.facebook.react.ReactApplication;
+import com.horcrux.svg.RNSvgPackage;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
@@ -24,7 +25,8 @@ public class MainApplication extends Application implements ReactApplication {
     @Override
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
-          new MainReactPackage()
+          new MainReactPackage(),
+            new RNSvgPackage()
       );
     }
   };

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'HoopDreams'
+include ':react-native-svg'
+project(':react-native-svg').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-svg/android')
 
 include ':app'
 include ':react-native-lock'

--- a/app/components/App.js
+++ b/app/components/App.js
@@ -46,6 +46,7 @@ export default class App extends Component {
 
 var NavigationBarRouteMapper = {
   LeftButton(route, navigator) {
+    if(route.title === "Login to access NBA data") { return null }
     if(route.title !== "User Profile") {
       return (
         <TouchableHighlight onPress={() => navigator.push({
@@ -70,6 +71,7 @@ var NavigationBarRouteMapper = {
   },
 
   RightButton(route, navigator) {
+     if(route.title === "Login to access NBA data") { return null }
     if(route.title !== "Pick a team") {
       return (
         <TouchableHighlight onPress={(index) => navigator.push({

--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -23,13 +23,14 @@ import teamContainer from '../containers/teamContainer';
 import userContainer from '../containers/userContainer';
 import Login from '../components/Login';
 
+import { Pie } from 'react-native-pathjs-charts';
+
 const apiEndpoint = 'http://localhost:3001/';
 
 class Home extends Component{
   constructor (props) {
    super(props);
    this.state = {
-     players: [],
      selectedTeam: 1610612739,
    };
  }
@@ -41,20 +42,48 @@ class Home extends Component{
     .then(responseText => {
       mapTeamToStore(JSON.parse(responseText));
     })
-    .then(() => {
-      const teamData = this.props.teamData.toArray();
-      this.setState({ teamData });
-    })
     .catch(err => console.log('Error fetching team: ',err));
 }
 
  render() {
-   const { team, user } = this.props;
+   const { user } = this.props;
+   let teamData;
+   if (!!this.props.teamData) { 
+     teamData = this.props.teamData.toArray();
+
+     console.log('team data!!', teamData);
+  }
+   let options = {
+      margin: {
+        top: 20,
+        left: 10,
+        right: 20,
+        bottom: 20
+      },
+      width: 350,
+      height: 350,
+      color: '#FFEBCD',
+      r: 50,
+      R: 150,
+      legendPosition: 'topLeft',
+      animate: {
+        type: 'oneByOne',
+        duration: 200,
+        fillTransition: 3
+      },
+      label: {
+        fontFamily: 'Arial',
+        fontSize: 8,
+        fontWeight: true,
+        color: '#ECF0F1'
+      }
+    };
+
+
    if(user) {
      return (
        <View >
           <Picker
-           style={styles.scrollView}
            selectedValue={this.state.selectedTeam}
            onValueChange={(team) => {
              this.setState({ selectedTeam: team })
@@ -66,6 +95,26 @@ class Home extends Component{
          <TouchableHighlight onPress={() => this.fetchTeamDashboard()}>
           <Text>Set Team</Text>
         </TouchableHighlight>
+        {!!teamData ? 
+        <View style={styles.charts}>
+          <Text>Offensive Rebounds by Player</Text>
+          <Pie
+            data={teamData}
+            options={options}
+            accessorKey="oreb" />
+          <Text>Defensive rebounds by Player</Text>
+          <Pie
+            data={teamData}
+            options={options}
+            accessorKey="dreb" />
+          <Text>Win Percentage</Text>
+          <Pie
+            data={teamData}
+            options={options}
+            accessorKey="wPct" />
+      </View>
+          : f => f
+        }
        </View>
      )
    }
@@ -85,64 +134,7 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     backgroundColor: '#fff',
   },
-  messageBox: {
-    flex: 1,
-    marginTop: 100,
-  },
-  avatar: {
-    alignSelf: 'center',
-    height: 100,
-    width: 100,
-    borderRadius: 50,
-    top: 80,
-  },
-  form: {
-    height: 40,
-    borderColor: 'gray',
-    borderWidth: 1,
-    top: 85,
-    padding: 5,
-    marginBottom: 15,
-    marginLeft: 15,
-    marginRight: 15,
-  },
-  ebook: {
-    top: 95,
-    left: 15,
-    marginBottom: 10,
-  },
-  orderByNewest: {
-    top: 55,
-    left: 150,
-    marginBottom: 10,
-  },
-  eBookLabel: {
-    top: 50,
-    left: 15,
-    marginBottom: 10,
-    fontSize: 12,
-  },
-  newestLabel: {
-    top: 25,
-    left: 150,
-    marginBottom: 10,
-    fontSize: 12,
-  },
-  callApiButton: {
-    height: 50,
-    alignSelf: 'stretch',
-    backgroundColor: '#fff',
-    borderColor: '#1E77E2',
-    borderWidth: 2,
-    margin: 10,
-    shadowColor: '#1b71E2',
-    shadowRadius: 10,
-    borderRadius: 5,
-    top: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  apiButtonLabel: {
-    fontSize: 24,
-  },
+  charts: {
+    flexDirection: 'column',
+  }
 });

--- a/app/reducers/team.js
+++ b/app/reducers/team.js
@@ -1,6 +1,6 @@
 'use strict';
 import { List } from 'immutable';
-const teamData = (state = [], action) => {
+const teamData = (state = null, action) => {
   
   switch (action.type) {
     case 'FETCH_TEAM':

--- a/ios/HoopDreams.xcodeproj/project.pbxproj
+++ b/ios/HoopDreams.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		0039FAABBDAF1766E2AE0D02 /* libPods-HoopDreams.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B594664CC606DEE8391AF94 /* libPods-HoopDreams.a */; };
 		00C302E51ABCBA2D00DB3ED1 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
@@ -27,6 +26,7 @@
 		3D9E70FB091C371C4F863571 /* libPods-HoopDreamsTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AD487F80181272F215DFA96 /* libPods-HoopDreamsTests.a */; };
 		5E9157361DD0AC6A00FF2AA8 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		832341BD1AAA6AB300B99B32 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
+		2EC0D7C58A1A43D9A403A4A1 /* libRNSVG.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 996901F4013142D6B6D25F02 /* libRNSVG.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -154,6 +154,8 @@
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 		A9D5280C804226CF2B749503 /* Pods-HoopDreamsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HoopDreamsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-HoopDreamsTests/Pods-HoopDreamsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		AFD8F7AB786B0D0BD481D02B /* Pods-HoopDreams.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HoopDreams.debug.xcconfig"; path = "Pods/Target Support Files/Pods-HoopDreams/Pods-HoopDreams.debug.xcconfig"; sourceTree = "<group>"; };
+		E76D211D0501462DB84596D7 /* RNSVG.xcodeproj */ = {isa = PBXFileReference; name = "RNSVG.xcodeproj"; path = "../node_modules/react-native-svg/ios/RNSVG.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		996901F4013142D6B6D25F02 /* libRNSVG.a */ = {isa = PBXFileReference; name = "libRNSVG.a"; path = "libRNSVG.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -183,6 +185,7 @@
 				139FDEF61B0652A700C62182 /* ReferenceProxy in Frameworks */,
 				19076778980144CBBADF53E1 /* libA0RNLock.a in Frameworks */,
 				0039FAABBDAF1766E2AE0D02 /* libPods-HoopDreams.a in Frameworks */,
+				2EC0D7C58A1A43D9A403A4A1 /* libRNSVG.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -316,6 +319,7 @@
 				00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */,
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
 				2DDE3DD64C414292A7A1A446 /* A0RNLock.xcodeproj */,
+				E76D211D0501462DB84596D7 /* RNSVG.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -765,6 +769,7 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HoopDreams.app/HoopDreams";
@@ -782,6 +787,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -865,6 +871,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native/ReactCommon/**",
 					"$(SRCROOT)/../node_modules/react-native-lock/ios/A0RNLock/**",
+					"$(SRCROOT)/../node_modules/react-native-svg/ios/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -906,6 +913,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native/ReactCommon/**",
 					"$(SRCROOT)/../node_modules/react-native-lock/ios/A0RNLock/**",
+					"$(SRCROOT)/../node_modules/react-native-svg/ios/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "15.4.1",
     "react-native": "0.39.2",
     "react-native-lock": "^0.4.0",
+    "react-native-pathjs-charts": "0.0.22",
     "react-redux": "^5.0.1",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0"

--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ app.get('/:TeamID', function(req, res) {
     response.playersSeasonTotals.map((player) => {
       let obj = {};
       const { playerName, wPct, playerId, pts, oreb, dreb, ast, stl, blk, tov } = player;
-      Object.assign(obj, { playerName, wPct, playerId, pts, oreb, dreb, ast, stl, blk, tov });
+      Object.assign(obj, { name: playerName, wPct, playerId, pts, oreb, dreb, ast, stl, blk, tov });
       result.push(obj);
     });
     res.send(result);


### PR DESCRIPTION
## Purpose
This PR adds the react-native-pathjs-charts library.  This library lets us quickly make pi charts from our API data.

## Approach
We are importing the Pie component from the library, passing it some default styling options and passing it our team data.  We are creating charts based on different stats we're getting back from our API. 
We used the wiki/docs from the library to get the charts going.  We had some issues because it requires a 'name' field that we weren't passing.  We updated the API on our server to pass this down.

## Open Questions and Pre-Merge TODOs
This PR is ready to merge pending code review.